### PR TITLE
bugfix for when dropTable is called, the table can not reused

### DIFF
--- a/src/main/java/io/hgraphdb/HBaseGraphUtils.java
+++ b/src/main/java/io/hgraphdb/HBaseGraphUtils.java
@@ -165,6 +165,7 @@ public final class HBaseGraphUtils {
             admin.disableTable(tableName);
         }
         admin.truncateTable(tableName, true);
+        admin.enableTable(tableName);
     }
 
     private static byte[] getStartKey(int regionCount) {


### PR DESCRIPTION
I want to clear all data in graph tables and preserve the table metadata, but when dropTable method is called, the table can not reused. this patch is bugfix for it 
```
Exception in thread "main" io.hgraphdb.HBaseGraphException: org.apache.hadoop.hbase.TableNotEnabledException: testgraph:indexMetadata is disabled.
```